### PR TITLE
Chapter 3, Section 4 (version 1.0)

### DIFF
--- a/source/mac/StartSwiftKickstart/03VariablesAndConstants.playground/Pages/04UsingVariablesAndConstants.xcplaygroundpage/Contents.swift
+++ b/source/mac/StartSwiftKickstart/03VariablesAndConstants.playground/Pages/04UsingVariablesAndConstants.xcplaygroundpage/Contents.swift
@@ -1,14 +1,14 @@
 //: ### Using Variables and Constants
 //: [TOC](00TOC) | [Previous](@previous) | [Next](@next)
 
-func hello(peopleNamed people: String...) -> (count: Int,
-    greeting: String) {
+func hello(_ people: String...) -> (count: Int,
+                                    greeting: String) {
         (people.count, people.reduce(""){
             $0 + "\nHello, " + $1 + "!"
         })
 }
 
-hello(peopleNamed: "Thing One", "Thing Two")
+hello("Thing One", "Thing Two")
 print("Hi")
 //: [TOC](00TOC) | [Previous](@previous) | [Next](@next)
 

--- a/source/mac/StartSwiftKickstart/03VariablesAndConstants.playground/Pages/04UsingVariablesAndConstants.xcplaygroundpage/Contents.swift
+++ b/source/mac/StartSwiftKickstart/03VariablesAndConstants.playground/Pages/04UsingVariablesAndConstants.xcplaygroundpage/Contents.swift
@@ -9,6 +9,5 @@ func hello(_ people: String...) -> (count: Int,
 }
 
 hello("Thing One", "Thing Two")
-print("Hi")
 //: [TOC](00TOC) | [Previous](@previous) | [Next](@next)
 


### PR DESCRIPTION
Subsection "Starting Point" (PDF page 126)

Match the content of the book by removing the external label.
I assumed this was the updated way, observing the extra spacing for the following line in the book.

```swift
                                              greeting: String) {
```