### PR TITLE
Chapter 9, Section 11 (version 1.0)

### DIFF
--- a/source/mac/StartSwiftKickstart/09Errors.playground/Pages/11Result.xcplaygroundpage/Contents.swift
+++ b/source/mac/StartSwiftKickstart/09Errors.playground/Pages/11Result.xcplaygroundpage/Contents.swift
@@ -9,7 +9,7 @@ extension SubscriptOutOfBoundsError : CustomDebugStringConvertible {
   var debugDescription: String {
     switch self {
     case .negativeIndexError:
-      return "is less than zero"
+      return "Index is less than zero"
     case .indexIsTooLargeError(let excess):
       return "Index is greater than \(Forecast.count-1) by \(excess)"
     }


### PR DESCRIPTION
Subsection "Using Result" (PDF page 542)

Match string with other examples and outputs that appears in the book.

> failure(Index is greater than 4 by 16)