### PR TITLE
Added the missing description

### DIFF
--- a/source/mac/SwiftKickstart/11HigherOrderFunctions.playground/Pages/06MappingArrays.xcplaygroundpage/Contents.swift
+++ b/source/mac/SwiftKickstart/11HigherOrderFunctions.playground/Pages/06MappingArrays.xcplaygroundpage/Contents.swift
@@ -22,6 +22,6 @@ func myMap<Input, Output>(to input: [Input],
 }
 
 myMap(to: numberSold,
-      using: revenueAt199on)
+      using: revenueAt199on).description
 
 //: [TOC](00TOC) | [Previous](@previous) | [Next](@next)


### PR DESCRIPTION
Subsection "Using our new map" (PDF page 631)

Added missing `.description` to the expected code.

The explanation in the book is duplicated.


> Let's make the result a bit more reader-friendly by filling the Array with the description of the USDollar values.

```swift
myMap(to: numberSold,
      using: revenueAt199on).description
}
```

> Instead of applying description to each element of the Array, we can apply it to the resulting Array like this.

```swift
myMap(to: numberSold,
      using: revenueAt199on).description
```

There is also a extra `{` in the first code.

Also the result I got was

> "[$23.68, $40.40, $15.32, $20.90, $44.58, $29.25, $37.61]"

and not

> ["$23.68", "$40.40", "$15.32", "$20.90", "$44.58", "$29.25", "$37.61"]

as in the book.

Xcode 12.5 12E262
